### PR TITLE
make destroy emit error/close

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,8 +84,8 @@ streamIt.prototype._transform = function (data, enc, next) {
 streamIt.prototype.destroy = function (err) {
   if (this.destroyed) return
   this.destroyed = true
-  this.err = err
-  this.end()
+  if (err) this.emit('error', err)
+  this.emit('close')
 }
 
 function simplediffer (changes, opts, cb) {


### PR DESCRIPTION
`.end()` isn't guaranteed to emit `end` if you never drain the stream so we usually always emit close on destroy as an indication that the stream was destroyed
